### PR TITLE
Fix readers in query/name

### DIFF
--- a/src/common/net/indexed-buffer.ts
+++ b/src/common/net/indexed-buffer.ts
@@ -18,6 +18,10 @@ export class IndexedBuffer {
     return this.buffer.length - this.index;
   }
 
+  readBoolean() {
+    return !!this.readStandard(this.buffer.readUint8, 1);
+  }
+
   readUInt8() {
     return this.readStandard(this.buffer.readUint8, 1);
   }

--- a/src/worldserver/query/name.ts
+++ b/src/worldserver/query/name.ts
@@ -13,11 +13,11 @@ export class NameQuery extends ClientRequest {
     return new Promise((resolve) => {
       this.world.once("packet:receive:SMSG_NAME_QUERY_RESPONSE", (gp) => {
         const guid = gp.readPackedGUID();
-        const name_known = gp.readUnsignedByte();
+        const name_known = gp.readUInt8();
         if (!name_known) {
           return resolve("");
         }
-        const name = gp.readCString();
+        const name = gp.readRawString();
         resolve(name);
       });
       this.world.send(app);

--- a/src/worldserver/query/name.ts
+++ b/src/worldserver/query/name.ts
@@ -13,7 +13,7 @@ export class NameQuery extends ClientRequest {
     return new Promise((resolve) => {
       this.world.once("packet:receive:SMSG_NAME_QUERY_RESPONSE", (gp) => {
         const guid = gp.readPackedGUID();
-        const name_known = gp.readUInt8();
+        const name_known = gp.readBoolean();
         if (!name_known) {
           return resolve("");
         }


### PR DESCRIPTION
These two readers don't exist anymore (or ever?).

I tried to copy some other implementations of reading chat, but no matter what I try, the byte after `name_known` is always 0? Not sure what to do about that.

I also added a `readBoolean` helper. Let me know what you think about that. Not sure if you think it's a faux-pas.